### PR TITLE
Support other browser vendors than Chrome

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,6 +1,6 @@
 const supportedProjects = ['spring-boot', 'spring'];
 
-chrome.extension.sendMessage({}, function (response) {
+browser.runtime.sendMessage({}, function (response) {
     var readyStateCheckInterval = setInterval(function () {
         if (document.readyState === "complete") {
             clearInterval(readyStateCheckInterval);


### PR DESCRIPTION
To support the Safari Extension (https://github.com/maciejwalkowiak/spring-docs-read-latest-extension/issues/2) the `inject.js` can't reference `chrome.*` dependencies.

I have a POC working and will follow up with another PR 👍 
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/50061/116977528-d610f300-acc2-11eb-85a5-cdd0eeb4cd20.png">
