### PR TITLE
Fix URL project name from "spring" to "spring-framework"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spring Docs Read Latest Extension",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "manifest_version": 2,
   "description": "Adds link to latest Spring docs to older versions project references",
   "homepage_url": "http://github.com/maciejwalkowiak",

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,4 +1,4 @@
-const supportedProjects = ['spring-boot', 'spring'];
+const supportedProjects = ['spring-boot', 'spring-framework'];
 
 chrome.extension.sendMessage({}, function (response) {
     var readyStateCheckInterval = setInterval(function () {


### PR DESCRIPTION
To reflect current doc URLs.

Updated version to 0.0.2.

Fixes issue #5.