### PR TITLE
Add close button & fix header layout

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spring Docs Read Latest Extension",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "manifest_version": 2,
   "description": "Adds link to latest Spring docs to older versions project references",
   "homepage_url": "http://github.com/maciejwalkowiak",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spring Docs Read Latest Extension",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "manifest_version": 2,
   "description": "Adds link to latest Spring docs to older versions project references",
   "homepage_url": "http://github.com/maciejwalkowiak",

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -3,15 +3,17 @@
  **/
 
 .spring-latest-docs-note {
-    z-index: 9999;
-    text-align: center;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width:100%;
     padding: 5px;
     background-color: #5CA730;
-    color: #caeab8
+    color: #caeab8;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.spring-latest-docs-note > div {
+    flex: 1;
+    text-align: center;
 }
 
 .spring-latest-docs-note > a {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,4 +1,4 @@
-const supportedProjects = ['spring-boot', 'spring'];
+const supportedProjects = ['spring-boot', 'spring-framework'];
 
 chrome.extension.sendMessage({}, function (response) {
     var readyStateCheckInterval = setInterval(function () {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,5 +1,27 @@
 const supportedProjects = ['spring-boot', 'spring-framework'];
 
+function addLaterVersionHeader(project, urlLatestVersion) {
+	const status = document.createElement('div');
+	status.classList.add('spring-latest-docs-note');
+	status.id = 'spring-latest-docs-note';
+	status.innerHTML = `
+						<div>This is the documentation for an older version of <strong>${project}</strong>. 
+						<a href="${urlLatestVersion}">
+						   <strong>Read Latest</strong>
+						</a>
+            			</div>
+            			<button id='spring-latest-docs-note-close'>Close</button>`;
+
+	document.body.prepend(status);
+
+	const closeButton = document.getElementById('spring-latest-docs-note-close')
+	closeButton.addEventListener('click', function() {
+				const div = document.getElementById('spring-latest-docs-note')
+				document.body.removeChild(div)
+			}
+	);
+}
+
 chrome.extension.sendMessage({}, function (response) {
     var readyStateCheckInterval = setInterval(function () {
         if (document.readyState === "complete") {
@@ -12,18 +34,9 @@ chrome.extension.sendMessage({}, function (response) {
 				const { groups: { project, version } } = regExp.exec(url);
 
 				if (supportedProjects.includes(project) && version !== 'current') {
-					const currentUrl = url.replace(regExp, `$1${project}$3current/$5`)
+					const urlLatestVersion = url.replace(regExp, `$1${project}$3current/$5`)
 
-					const status = document.createElement("div")
-					status.classList.add("spring-latest-docs-note")
-					status.innerHTML = `
-						This is the documentation for an older version of <strong>${project}</strong>. 
-						<a href="${currentUrl}">
-						   <strong>Read Latest</strong>
-						</a>`;
-
-					document.body.prepend(status);
-					document.body.style.paddingTop += 20;
+					addLaterVersionHeader(project, urlLatestVersion);
 				}
 			}
         }


### PR DESCRIPTION
Now that Spring Boot 3.x and Spring Framework 6.x are out, the "latest" version may not be what I want. I may want the Spring Boot 2.7.7 docs and not the 3.x ("current") docs. Added a close button so I can not be bothered by it in this case.